### PR TITLE
🛠 Fix UTF-32LE detection for string tests

### DIFF
--- a/include/ztd/tests/basic_unicode_strings.hpp
+++ b/include/ztd/tests/basic_unicode_strings.hpp
@@ -49,7 +49,8 @@
 namespace ztd { namespace tests {
 
 	inline constexpr bool wide_is_utf32
-		= ::ztd::is_encoding_name_equal(ZTD_CXX_COMPILE_TIME_WIDE_ENCODING_NAME_GET_I_(), "UTF-32");
+		= ::ztd::is_encoding_name_equal(ZTD_CXX_COMPILE_TIME_WIDE_ENCODING_NAME_GET_I_(), "UTF-32")
+		|| ::ztd::is_encoding_name_equal(ZTD_CXX_COMPILE_TIME_WIDE_ENCODING_NAME_GET_I_(), "UTF-32LE");
 	inline constexpr bool wide_is_utf16
 		= ::ztd::is_encoding_name_equal(ZTD_CXX_COMPILE_TIME_WIDE_ENCODING_NAME_GET_I_(), "UTF-16");
 	inline constexpr bool wide_is_utf8


### PR DESCRIPTION
Necessary to fix ztd::text tests on newer version of GCC, see https://github.com/soasis/text/pull/25