### PR TITLE
🛠 Fix Windows UWP ✨for real for real✨

### DIFF
--- a/include/ztd/idk/detail/windows.hpp
+++ b/include/ztd/idk/detail/windows.hpp
@@ -52,7 +52,6 @@
 #include <ciso646>
 #include <cwchar>
 #include <locale>
-#else
 #endif
 
 ZTD_EXTERN_C_OPEN_I_
@@ -63,14 +62,10 @@ ZTD_EXTERN_C_CLOSE_I_
 #include <ztd/prologue.hpp>
 
 #if !defined(_KERNELX) && !defined(_ONECORE)
-#if defined(WINAPI_FAMILY_PARTITION) && defined(WINAPI_FAMILY_DESKTOP_APP)
-#if WINAPI_FAMILY_PARTITION(WINAPI_FAMILY_DESKTOP_APP)
+#if defined(WINAPI_FAMILY) || defined(WINAPI_FAMILY_APP)
+#define ZTD_FILEAPISAREANSI_I_ ZTD_OFF
+#else
 #define ZTD_FILEAPISAREANSI_I_ ZTD_ON
-#else
-#define ZTD_FILEAPISAREANSI_I_ ZTD_OFF
-#endif
-#else
-#define ZTD_FILEAPISAREANSI_I_ ZTD_OFF
 #endif
 #else
 #define ZTD_FILEAPISAREANSI_I_ ZTD_OFF


### PR DESCRIPTION
Tested on a real life Windows machine with real life UWP

If `WINAPI_FAMILY` or `WINAPI_FAMILY_APP` are defined _at all_, we're in UWP land. There's more to how the header works than that, but it's irrelevant since the ANSI APIs aren't available under any circumstances when we're in UWP. `WINAPI_FAMILY_DESKTOP_APP` is always _defined_ regardless of whether it's the family in use (and it doesn't have ANSI functions either) which is what break UWP support right now.

