### PR TITLE
🛠 Install and configure cmake exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ target_link_libraries(ztd.idk
 		ztd::version
 		ztd::tag_invoke
 )
-if (ZTD_IDK_IS_TOP_LEVEL_PROJECT) 
+if (ZTD_IDK_IS_TOP_LEVEL_PROJECT)
 	target_compile_options(ztd.idk
 		PRIVATE
 			${--utf8-literal-encoding}
@@ -230,6 +230,11 @@ write_basic_package_version_file(
 export(TARGETS ztd.idk
 	FILE
 	"${CMAKE_CURRENT_BINARY_DIR}/cmake/ztd.idk/ztd.idk-targets.cmake"
+)
+
+install(
+	DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/cmake"
+	TYPE DATA
 )
 
 if (ZTD_IDK_GENERATE_SINGLE)

--- a/cmake/ztd.idk-config.cmake.in
+++ b/cmake/ztd.idk-config.cmake.in
@@ -1,6 +1,11 @@
 @PACKAGE_INIT@
 
-if (TARGET ztd::idk)
+find_package(ztd.version CONFIG REQUIRED)
+find_package(ztd.tag_invoke CONFIG REQUIRED)
+include(${CMAKE_CURRENT_LIST_DIR}/ztd.idk-targets.cmake)
+
+if (TARGET ztd.idk)
+	add_library(ztd::idk ALIAS ztd.idk)
 	get_target_property(ZTD_IDK_INCLUDE_DIRS
 		ztd.idk INTERFACE_INCLUDE_DIRECTORIES)
 	set_and_check(ZTD_IDK_INCLUDE_DIRS "${ZTD_IDK_INCLUDE_DIRS}")

--- a/cmake/ztd.tag_invoke-config.cmake.in
+++ b/cmake/ztd.tag_invoke-config.cmake.in
@@ -1,6 +1,10 @@
 @PACKAGE_INIT@
 
-if (TARGET ztd::tag_invoke)
+find_package(ztd.version CONFIG REQUIRED)
+include(${CMAKE_CURRENT_LIST_DIR}/ztd.tag_invoke-targets.cmake)
+
+if (TARGET ztd.tag_invoke)
+	add_library(ztd::tag_invoke ALIAS ztd.tag_invoke)
 	get_target_property(ZTD_TAG_INVOKE_INCLUDE_DIRS
 		ztd.tag_invoke INTERFACE_INCLUDE_DIRECTORIES)
 	set_and_check(ZTD_TAG_INVOKE_INCLUDE_DIRS "${ZTD_TAG_INVOKE_INCLUDE_DIRS}")

--- a/cmake/ztd.version-config.cmake.in
+++ b/cmake/ztd.version-config.cmake.in
@@ -1,6 +1,9 @@
 @PACKAGE_INIT@
 
-if (TARGET ztd::version)
+include(${CMAKE_CURRENT_LIST_DIR}/ztd.version-targets.cmake)
+
+if (TARGET ztd.version)
+	add_library(ztd::version ALIAS ztd.version)
 	get_target_property(ZTD_VERSION_INCLUDE_DIRS
 		ztd.version INTERFACE_INCLUDE_DIRECTORIES)
 	set_and_check(ZTD_VERSION_INCLUDE_DIRS "${ZTD_VERSION_INCLUDE_DIRS}")


### PR DESCRIPTION
`.cmake` files need to be installed in order for downstream dependencies to find them. Similarly, the configure script for a `.cmake` package needs to `find_package()` its dependencies and `include()` its generated export script.

Finally, the target name for our export scripts is not `ztd::target` but rather `ztd.target`, so we need to manually setup the aliases after the export script has run.

I don't know what `ztd::target::single` is supposed to be, but right now it does nothing as no such target exists in our export scripts. I left it alone on the idea it's best for me to not touch things I don't understand.

The goal of these changes is to allow users of `ztd::text` to use `find_package()` in their cmake scripts. I've tested these changes with my own vcpkg registry at: https://github.com/nickelpro/vito-reg

